### PR TITLE
Add old functionality

### DIFF
--- a/src/main/java/cami/CLI.java
+++ b/src/main/java/cami/CLI.java
@@ -34,11 +34,6 @@ public class CLI {
                     "would download everything. Number of Threads is optional. Default: 10";
     private static final String DOWNLOAD_SWIFT_OPT_NAME = "d";
 
-    private static final String LIST_SWIFT_ARG_NAME = "url";
-    private static final String LIST_SWIFT_LONG_OPT_NAME = "list";
-    private static final String LIST_SWIFT_DESCRIPTION = "Retrieves a list the data in Swift Container";
-    private static final String LIST_SWIFT_OPT_NAME = "l";
-
     private static final String ASSEMBLY_ARG_NAME = "assembly_file";
     private static final String ASSEMBLY_LONG_OPT_NAME = "assemblyFingerprint";
     private static final String ASSEMBLY_DESCRIPTION = "Computes fingerprint of an assembly file.";
@@ -98,8 +93,6 @@ public class CLI {
             runUpload(line);
         } else if (line.hasOption(DOWNLOAD_SWIFT_OPT_NAME) || line.hasOption(DOWNLOAD_SWIFT_LONG_OPT_NAME)) {
             runDownload(line);
-        } else if (line.hasOption(LIST_SWIFT_OPT_NAME) || line.hasOption(LIST_SWIFT_LONG_OPT_NAME)) {
-            runList(line);
         } else if (line.hasOption(VERSION_LONG_OPT_NAME) || line.hasOption(VERSION_OPT_NAME)) {
             System.out.println("Version:" + VERSION);
         } else {
@@ -158,9 +151,6 @@ public class CLI {
             threads = Integer.parseInt(args[3]);
         }
         try {
-            if (source.endsWith("/")) {
-                source = source.replaceFirst(".$", "");
-            }
             SwiftDownload swiftDownload = new SwiftDownload();
             swiftDownload.downloadAll(source, destination, regex, threads);
         } catch (Exception ex) {
@@ -168,22 +158,6 @@ public class CLI {
         }
     }
 
-    private void runList(CommandLine line) throws IOException {
-        String[] args = line.getOptionValues(LIST_SWIFT_OPT_NAME);
-        if (args.length != 1) {
-            throw new IOException(String.format(NOT_ENOUGH_PARAMETER, LIST_SWIFT_ARG_NAME));
-        }
-        String source = args[0];
-        try {
-            if (source.endsWith("/")) {
-                source = source.replaceFirst(".$", "");
-            }
-            SwiftDownload swiftDownload = new SwiftDownload();
-            System.out.println(swiftDownload.list(source));
-        } catch (Exception ex) {
-            System.out.println(ex.getMessage());
-        }
-    }
 
     @SuppressWarnings("static-access")
     private static Options buildCommandLineOptions() {
@@ -219,12 +193,6 @@ public class CLI {
                 .hasArgs(4)
                 .withDescription(DOWNLOAD_SWIFT_DESCRIPTION)
                 .create(DOWNLOAD_SWIFT_OPT_NAME));
-        // List Swift option
-        options.addOption(OptionBuilder.withArgName(LIST_SWIFT_ARG_NAME)
-                .withLongOpt(LIST_SWIFT_LONG_OPT_NAME)
-                .hasArgs(1)
-                .withDescription(LIST_SWIFT_DESCRIPTION)
-                .create(LIST_SWIFT_OPT_NAME));
         // Help option
         options.addOption(OptionBuilder.withLongOpt(HELP_LONG_OPT_NAME)
                 .withDescription(HELP_DESCRIPTION)

--- a/src/main/java/cami/CLI.java
+++ b/src/main/java/cami/CLI.java
@@ -27,7 +27,7 @@ public class CLI {
     private static final String HELP_DESCRIPTION = "Print the help of the application";
     private static final String HELP_OPT_NAME = "h";
 
-    private static final String DOWNLOAD_SWIFT_ARG_NAME = "url destination pattern threads";
+    private static final String DOWNLOAD_SWIFT_ARG_NAME = "linkfile destination pattern threads";
     private static final String DOWNLOAD_SWIFT_LONG_OPT_NAME = "download";
     private static final String DOWNLOAD_SWIFT_DESCRIPTION =
             "Downloads data from Swift. You have to provide a pattern for downloading files. A simple '.' " +

--- a/src/main/java/cami/download/SwiftDownload.java
+++ b/src/main/java/cami/download/SwiftDownload.java
@@ -38,6 +38,12 @@ public class SwiftDownload {
             e.printStackTrace();
 	}
 
+	// hack to avoid changing ObjectStorageWrapper
+	String[] stemComponents = tmpStem.split("/");
+	int lastStemComponentLength = stemComponents[stemComponents.length-1].length()+1;
+	tmpStem = tmpStem.substring(lastStemComponentLength);
+	System.out.println(tmpStem);
+
 	final String stem = tmpStem;
  
         ForkJoinPool forkJoinPool = new ForkJoinPool(threads);

--- a/src/main/java/cami/download/SwiftDownload.java
+++ b/src/main/java/cami/download/SwiftDownload.java
@@ -17,7 +17,29 @@ import java.util.stream.Collectors;
 
 public class SwiftDownload {
 
-    public void downloadAll(String urlFile, String destination, String regex, int threads) {
+    public void downloadAll(String source, String destination, String regex, int threads) {
+	if (source.substring(0,8).equals("https://") || source.substring(0,7).equals("http://")) {
+		urlDownloadAll(source, destination, regex, threads);
+	} else {
+		fileDownloadAll(source, destination, regex, threads);
+	}
+    }
+
+    public void urlDownloadAll(String url, String destination, String regex, int threads) {
+        List<String> files = getFiles(url);
+        ForkJoinPool forkJoinPool = new ForkJoinPool(threads);
+        try {
+            forkJoinPool.submit(() ->
+                    files.stream().parallel()
+                            .filter(file -> !file.endsWith("/"))
+                            .filter(file -> urlMatchesRegex(regex, file))
+                            .forEach(file -> urlDownload(url + "/" + file, Paths.get(destination, file).toString()))).get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void fileDownloadAll(String urlFile, String destination, String regex, int threads) {
       
         List<String> urls = new ArrayList<>();
 
@@ -50,14 +72,18 @@ public class SwiftDownload {
         try {
             forkJoinPool.submit(() ->
                     urls.stream().parallel()
-                            .filter(url -> matchesRegex(regex, url, stem))
-                            .forEach(url -> download(url, destination, stem))).get();
+                            .filter(url -> fileMatchesRegex(regex, url, stem))
+                            .forEach(url -> fileDownload(url, destination, stem))).get();
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
         }
     }
 
-    public static boolean matchesRegex(String regex, String text, String stem) {
+    public static boolean urlMatchesRegex(String regex, String text) {
+        return Pattern.compile(regex).matcher(text).find();
+    }
+
+    public static boolean fileMatchesRegex(String regex, String text, String stem) {
 
         String[] urlParts = text.split("[?]", 2);
         String bareUrl = urlParts[0];
@@ -68,8 +94,25 @@ public class SwiftDownload {
         return Pattern.compile(regex).matcher(fileNamePrefix).find();
     }
 
+    public void urlDownload(String url, String destination) {
+        System.out.println(String.join(" ", "Downloading", url, "to", destination));
+        URL website;
+        try {
+            website = new URL(url);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            return;
+        }
+        try (InputStream in = website.openStream()) {
+            File destinationFile = new File(destination);
+            destinationFile.getParentFile().mkdirs();
+            Files.copy(in, Paths.get(destination), new StandardCopyOption[]{StandardCopyOption.REPLACE_EXISTING});
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
-    public void download(String url, String destination, String stem) {
+    public void fileDownload(String url, String destination, String stem) {
 
         String[] urlParts = url.split("[?]", 2);
         String bareUrl = urlParts[0];
@@ -117,4 +160,38 @@ public class SwiftDownload {
 	    }
         }
     }
+
+    private List<String> getFiles(String url) {
+        List<String> fileList = new ArrayList<>();
+        List<String> finalList = new ArrayList<>();
+        boolean start = true;
+        String lastElement = "";
+        while (!fileList.isEmpty() || start) {
+            start = false;
+            URL website;
+            try {
+                website = new URL(url + lastElement);
+            } catch (MalformedURLException e) {
+                e.printStackTrace();
+                break;
+            }
+            try (InputStream in = website.openStream()) {
+                fileList = new BufferedReader(new InputStreamReader(in,
+                        StandardCharsets.UTF_8)).lines().collect(Collectors.toList());
+                if (fileList != null && !fileList.isEmpty()) {
+                    finalList.addAll(fileList);
+                    lastElement = "/?marker=" + fileList.get(fileList.size() - 1);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+                break;
+            }
+        }
+        return finalList;
+    }
+
+    public String list(String url) {
+        return String.join(System.getProperty("line.separator"), getFiles(url));
+    }
+
 }

--- a/src/test/java/cami/download/SwiftDownloadTest.java
+++ b/src/test/java/cami/download/SwiftDownloadTest.java
@@ -10,20 +10,23 @@ import java.nio.file.Paths;
 import static org.junit.Assert.assertTrue;
 
 public class SwiftDownloadTest {
-    // private static String CONTAINER_URL = "https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/CAMI_TEST";
+    private static String CONTAINER_URL = "https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/CAMI_TEST";
     private static String TEST_URL_FILE = "src/test/resources/test_url_file";
 
 
     // Replace New File with new TemporaryFolder().getRoot() for genuine temp path
 
     // @Rule
-    public String tempFolder = new File("/tmp/test").getAbsolutePath();
+    public String fileTempFolder = new File("/tmp/test").getAbsolutePath();
+
+    @Rule
+    public TemporaryFolder urlTempFolder = new TemporaryFolder();
 
     boolean foo = new File("/tmp/test").mkdirs();
 
     @Test
-    public void canDownloadFile() throws Exception {
-        String testFilePath = Paths.get(tempFolder, "test").toString();
+    public void fileCanDownloadFile() throws Exception {
+        String testFilePath = Paths.get(fileTempFolder, "test").toString();
         SwiftDownload download = new SwiftDownload();
         download.downloadAll(TEST_URL_FILE, testFilePath, ".", 1);
         File file = new File(testFilePath);
@@ -31,10 +34,28 @@ public class SwiftDownloadTest {
     }
 
     @Test
-    public void canDownloadSpecificFile() throws Exception {
-        String testFilePath = Paths.get(tempFolder, "test").toString();
+    public void urlCanDownloadFile() throws Exception {
+        String testFilePath = Paths.get(urlTempFolder.getRoot().getAbsolutePath(), "test").toString();
+        SwiftDownload download = new SwiftDownload();
+        download.downloadAll(CONTAINER_URL, testFilePath, ".", 1);
+        File file = new File(testFilePath);
+        assertTrue(file.exists());
+    }
+
+    @Test
+    public void fileCanDownloadSpecificFile() throws Exception {
+        String testFilePath = Paths.get(fileTempFolder, "test").toString();
         SwiftDownload download = new SwiftDownload();
         download.downloadAll(TEST_URL_FILE, testFilePath, "log", 1);
+        File file = new File(testFilePath);
+        assertTrue(file.exists());
+    }
+
+    @Test
+    public void urlCanDownloadSpecificFile() throws Exception {
+        String testFilePath = Paths.get(urlTempFolder.getRoot().getAbsolutePath(), "test").toString();
+        SwiftDownload download = new SwiftDownload();
+        download.downloadAll(CONTAINER_URL, testFilePath, "log", 1);
         File file = new File(testFilePath);
         assertTrue(file.exists());
     }

--- a/src/test/java/cami/download/SwiftDownloadTest.java
+++ b/src/test/java/cami/download/SwiftDownloadTest.java
@@ -10,32 +10,33 @@ import java.nio.file.Paths;
 import static org.junit.Assert.assertTrue;
 
 public class SwiftDownloadTest {
-    private static String CONTAINER_URL = "https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/CAMI_TEST";
+    // private static String CONTAINER_URL = "https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/CAMI_TEST";
+    private static String TEST_URL_FILE = "src/test/resources/test_url_file";
 
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    // Replace New File with new TemporaryFolder().getRoot() for genuine temp path
+
+    // @Rule
+    public String tempFolder = new File("/tmp/test").getAbsolutePath();
+
+    boolean foo = new File("/tmp/test").mkdirs();
 
     @Test
     public void canDownloadFile() throws Exception {
-        String testFilePath = Paths.get(tempFolder.getRoot().getAbsolutePath(), "test").toString();
+        String testFilePath = Paths.get(tempFolder, "test").toString();
         SwiftDownload download = new SwiftDownload();
-        download.downloadAll(CONTAINER_URL, testFilePath, ".", 1);
+        download.downloadAll(TEST_URL_FILE, testFilePath, ".", 1);
         File file = new File(testFilePath);
         assertTrue(file.exists());
     }
 
     @Test
     public void canDownloadSpecificFile() throws Exception {
-        String testFilePath = Paths.get(tempFolder.getRoot().getAbsolutePath(), "test").toString();
+        String testFilePath = Paths.get(tempFolder, "test").toString();
         SwiftDownload download = new SwiftDownload();
-        download.downloadAll(CONTAINER_URL, testFilePath, "log", 1);
+        download.downloadAll(TEST_URL_FILE, testFilePath, "log", 1);
         File file = new File(testFilePath);
         assertTrue(file.exists());
     }
 
-    @Test
-    public void canListBucket() throws Exception {
-        SwiftDownload download = new SwiftDownload();
-        assertTrue(download.list(CONTAINER_URL).contains("tmux-client-14010.log"));
-    }
 }

--- a/src/test/resources/test_url_file
+++ b/src/test/resources/test_url_file
@@ -1,0 +1,1 @@
+https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/NEWPRIVATETEST/traitar.png?temp_url_sig=d93b3f412176e6f1183367675272676b4e3ad03c&temp_url_expires=1539096105


### PR DESCRIPTION
Now allow:
-d linkfile [ for private stuff (or public) ]
-d URL [ for legacy public stuff ]

Also -l [ for legacy public stuff ] is back again

Version is now 1.6

Descriptions for toy datasets should be checked, in particular noting that threads and wildcards are now optional with -t and -p arguments.