### PR TITLE
fix: Allow downloading of public datasets via link. Also public list …

### DIFF
--- a/src/main/java/cami/download/SwiftDownload.java
+++ b/src/main/java/cami/download/SwiftDownload.java
@@ -17,7 +17,29 @@ import java.util.stream.Collectors;
 
 public class SwiftDownload {
 
-    public void downloadAll(String urlFile, String destination, String regex, int threads) {
+    public void downloadAll(String source, String destination, String regex, int threads) {
+	if (source.substring(0,8).equals("https://") || source.substring(0,7).equals("http://")) {
+		urlDownloadAll(source, destination, regex, threads);
+	} else {
+		fileDownloadAll(source, destination, regex, threads);
+	}
+    }
+
+    public void urlDownloadAll(String url, String destination, String regex, int threads) {
+        List<String> files = getFiles(url);
+        ForkJoinPool forkJoinPool = new ForkJoinPool(threads);
+        try {
+            forkJoinPool.submit(() ->
+                    files.stream().parallel()
+                            .filter(file -> !file.endsWith("/"))
+                            .filter(file -> urlMatchesRegex(regex, file))
+                            .forEach(file -> urlDownload(url + "/" + file, Paths.get(destination, file).toString()))).get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void fileDownloadAll(String urlFile, String destination, String regex, int threads) {
       
         List<String> urls = new ArrayList<>();
 
@@ -50,14 +72,18 @@ public class SwiftDownload {
         try {
             forkJoinPool.submit(() ->
                     urls.stream().parallel()
-                            .filter(url -> matchesRegex(regex, url, stem))
-                            .forEach(url -> download(url, destination, stem))).get();
+                            .filter(url -> fileMatchesRegex(regex, url, stem))
+                            .forEach(url -> fileDownload(url, destination, stem))).get();
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
         }
     }
 
-    public static boolean matchesRegex(String regex, String text, String stem) {
+    public static boolean urlMatchesRegex(String regex, String text) {
+        return Pattern.compile(regex).matcher(text).find();
+    }
+
+    public static boolean fileMatchesRegex(String regex, String text, String stem) {
 
         String[] urlParts = text.split("[?]", 2);
         String bareUrl = urlParts[0];
@@ -68,8 +94,25 @@ public class SwiftDownload {
         return Pattern.compile(regex).matcher(fileNamePrefix).find();
     }
 
+    public void urlDownload(String url, String destination) {
+        System.out.println(String.join(" ", "Downloading", url, "to", destination));
+        URL website;
+        try {
+            website = new URL(url);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            return;
+        }
+        try (InputStream in = website.openStream()) {
+            File destinationFile = new File(destination);
+            destinationFile.getParentFile().mkdirs();
+            Files.copy(in, Paths.get(destination), new StandardCopyOption[]{StandardCopyOption.REPLACE_EXISTING});
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
-    public void download(String url, String destination, String stem) {
+    public void fileDownload(String url, String destination, String stem) {
 
         String[] urlParts = url.split("[?]", 2);
         String bareUrl = urlParts[0];
@@ -117,4 +160,38 @@ public class SwiftDownload {
 	    }
         }
     }
+
+    private List<String> getFiles(String url) {
+        List<String> fileList = new ArrayList<>();
+        List<String> finalList = new ArrayList<>();
+        boolean start = true;
+        String lastElement = "";
+        while (!fileList.isEmpty() || start) {
+            start = false;
+            URL website;
+            try {
+                website = new URL(url + lastElement);
+            } catch (MalformedURLException e) {
+                e.printStackTrace();
+                break;
+            }
+            try (InputStream in = website.openStream()) {
+                fileList = new BufferedReader(new InputStreamReader(in,
+                        StandardCharsets.UTF_8)).lines().collect(Collectors.toList());
+                if (fileList != null && !fileList.isEmpty()) {
+                    finalList.addAll(fileList);
+                    lastElement = "/?marker=" + fileList.get(fileList.size() - 1);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+                break;
+            }
+        }
+        return finalList;
+    }
+
+    public String list(String url) {
+        return String.join(System.getProperty("line.separator"), getFiles(url));
+    }
+
 }

--- a/src/test/java/cami/download/SwiftDownloadTest.java
+++ b/src/test/java/cami/download/SwiftDownloadTest.java
@@ -10,20 +10,23 @@ import java.nio.file.Paths;
 import static org.junit.Assert.assertTrue;
 
 public class SwiftDownloadTest {
-    // private static String CONTAINER_URL = "https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/CAMI_TEST";
+    private static String CONTAINER_URL = "https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/CAMI_TEST";
     private static String TEST_URL_FILE = "src/test/resources/test_url_file";
 
 
     // Replace New File with new TemporaryFolder().getRoot() for genuine temp path
 
     // @Rule
-    public String tempFolder = new File("/tmp/test").getAbsolutePath();
+    public String fileTempFolder = new File("/tmp/test").getAbsolutePath();
+
+    @Rule
+    public TemporaryFolder urlTempFolder = new TemporaryFolder();
 
     boolean foo = new File("/tmp/test").mkdirs();
 
     @Test
-    public void canDownloadFile() throws Exception {
-        String testFilePath = Paths.get(tempFolder, "test").toString();
+    public void fileCanDownloadFile() throws Exception {
+        String testFilePath = Paths.get(fileTempFolder, "test").toString();
         SwiftDownload download = new SwiftDownload();
         download.downloadAll(TEST_URL_FILE, testFilePath, ".", 1);
         File file = new File(testFilePath);
@@ -31,10 +34,28 @@ public class SwiftDownloadTest {
     }
 
     @Test
-    public void canDownloadSpecificFile() throws Exception {
-        String testFilePath = Paths.get(tempFolder, "test").toString();
+    public void urlCanDownloadFile() throws Exception {
+        String testFilePath = Paths.get(urlTempFolder.getRoot().getAbsolutePath(), "test").toString();
+        SwiftDownload download = new SwiftDownload();
+        download.downloadAll(CONTAINER_URL, testFilePath, ".", 1);
+        File file = new File(testFilePath);
+        assertTrue(file.exists());
+    }
+
+    @Test
+    public void fileCanDownloadSpecificFile() throws Exception {
+        String testFilePath = Paths.get(fileTempFolder, "test").toString();
         SwiftDownload download = new SwiftDownload();
         download.downloadAll(TEST_URL_FILE, testFilePath, "log", 1);
+        File file = new File(testFilePath);
+        assertTrue(file.exists());
+    }
+
+    @Test
+    public void urlCanDownloadSpecificFile() throws Exception {
+        String testFilePath = Paths.get(urlTempFolder.getRoot().getAbsolutePath(), "test").toString();
+        SwiftDownload download = new SwiftDownload();
+        download.downloadAll(CONTAINER_URL, testFilePath, "log", 1);
         File file = new File(testFilePath);
         assertTrue(file.exists());
     }


### PR DESCRIPTION
Now allow:
-d linkfile [ for private stuff (or public) ]
-d URL [ for legacy public stuff ]

Also -l [ for legacy public stuff ] is back again

Version is now 1.6

Descriptions for toy datasets should be checked, in particular noting that threads and wildcards are now optional with -t and -p arguments.